### PR TITLE
update:titlepage,formpageのcssを変更

### DIFF
--- a/src/pages/form/Formpage.jsx
+++ b/src/pages/form/Formpage.jsx
@@ -55,183 +55,194 @@ export const Form = ({ name, setName, password, setPassword }) => {
         exit={{ opacity: 1 }} //ページを離れる時の動き
         transition={{ duration: 1 }}
       >
-        <Box>
-          <Stack
-            direction="column"
-            justifyContent="center"
-            alignItems="center"
-            spacing={3}
-            sx={{ mt: "20%" }}
-          >
-            {/* 名前入力 */}
-            <Typography
-              variant="body1"
-              sx={{
-                fontSize: "8vw",
-              }}
-            >
-              名前
-            </Typography>
-            <FormControl required color="primary" sx={{ width: "60%" }}>
-              <Input
-                placeholder="名前を入力"
-                name="Name"
-                autoComplete="off"
-                fullWidth
-                disableUnderline
-                onChange={handleNameChange}
-                sx={{
-                  padding: "10px",
-                  borderRadius: "15px",
-                  border: "3px solid white",
-                  backgroundColor: "white",
-                }}
-              />
-            </FormControl>
-
-            {/* 合言葉入力 */}
-            <Typography
-              variant="body1"
-              sx={{
-                fontSize: "8vw",
-              }}
-            >
-              合言葉
-            </Typography>
-            <FormControl required color="primary" sx={{ width: "60%" }}>
-              <Input
-                placeholder="合言葉を入力"
-                name="Password"
-                autoComplete="off"
-                fullWidth
-                disableUnderline
-                onChange={handlePassChange}
-                sx={{
-                  padding: "10px",
-                  borderRadius: "15px",
-                  border: "3px solid white",
-                  backgroundColor: "white",
-                }}
-              />
-            </FormControl>
-          </Stack>
-          <Box
-            component={motion.div}
-            initial={{ opacity: 0, y: 400 }} //初期
-            animate={{ opacity: 1, y: 0 }} //表示される時
-            exit={{ opacity: 1, y: -400 }} //ページを離れる時の動き
-            transition={{ type: "spring" }}
-          >
-            <Box
-              sx={{
-                mt: 5,
-                position: "relative",
-              }}
-            >
-              <img
-                src={fukidashiBackImg}
-                style={{
-                  width: "80%",
-                  height: "auto",
-                }}
-              />
-              <Typography
-                variant="body1"
-                sx={{
-                  margin: 0,
-                  whiteSpace: "pre-line",
-                  position: "absolute",
-                  width: "70%",
-                  top: "50%",
-                  left: "50%",
-                  transform: "translate(-50%, -55%)",
-                  fontSize: "8vw",
-                }}
-              >
-                ウォッチをつけてタップ
-              </Typography>
-            </Box>
-          </Box>
-
-          <Button
-            component={motion.button}
-            whileHover={{ scale: 1.0 }}
-            whileTap={{ scale: 0.8 }}
-            onClick={handleSubmit}
+        <Stack
+          direction="column"
+          justifyContent="center"
+          alignItems="center"
+          spacing={3}
+          sx={{ mt: "15vh" }}
+        >
+          {/* 名前入力 */}
+          <Typography
+            variant="body1"
             sx={{
-              fontSize: "8vw",
-              fontWeight: "bold",
-              color: "white",
-              backgroundColor: "#ffdbdb",
-              marginTop: "10%",
-              border: "10px solid white",
-              borderRadius: "15px",
-              padding: "2px 30px 2px 30px",
+              fontSize: "2.5rem",
             }}
           >
-            タップ
-          </Button>
-          <Modal
-            component={motion.div}
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={{ duration: 0.5 }}
-            open={open}
-            onClose={handleClose}
-            aria-labelledby="modal-modal-title"
-            aria-describedby="modal-modal-description"
+            名前
+          </Typography>
+          <FormControl
+            required
+            color="primary"
+            sx={{ width: "60%", maxWidth: "400px" }}
           >
-            <Box
+            <Input
+              placeholder="名前を入力"
+              name="Name"
+              autoComplete="off"
+              fullWidth
+              disableUnderline
+              onChange={handleNameChange}
               sx={{
+                padding: "1rem",
+                borderRadius: "15px",
+                border: "3px solid white",
+                backgroundColor: "white",
+              }}
+            />
+          </FormControl>
+
+          {/* 合言葉入力 */}
+          <Typography
+            variant="body1"
+            sx={{
+              fontSize: "2.5rem",
+            }}
+          >
+            合言葉
+          </Typography>
+          <FormControl
+            required
+            color="primary"
+            sx={{ width: "60%", maxWidth: "400px" }}
+          >
+            <Input
+              placeholder="合言葉を入力"
+              name="Password"
+              autoComplete="off"
+              fullWidth
+              disableUnderline
+              onChange={handlePassChange}
+              sx={{
+                padding: "1rem",
+                borderRadius: "15px",
+                border: "3px solid white",
+                backgroundColor: "white",
+              }}
+            />
+          </FormControl>
+        </Stack>
+        <Box
+          component={motion.div}
+          initial={{ opacity: 0, y: 400 }} //初期
+          animate={{ opacity: 1, y: 0 }} //表示される時
+          exit={{ opacity: 1, y: -400 }} //ページを離れる時の動き
+          transition={{ type: "spring" }}
+        >
+          <Box
+            sx={{
+              mt: 5,
+              position: "relative",
+            }}
+          >
+            <img
+              src={fukidashiBackImg}
+              style={{
+                width: "80%",
+                height: "auto",
+                maxWidth: "350px",
+              }}
+            />
+            <Typography
+              variant="body1"
+              sx={{
+                margin: 0,
+                whiteSpace: "pre-line",
                 position: "absolute",
+                width: "70%",
                 top: "50%",
                 left: "50%",
-                transform: "translate(-50%, -50%)",
-                width: "75vw",
-                bgcolor: "background.paper",
-                border: "3px solid #FF4BB7",
-                borderRadius: "30px",
-                p: "8vw",
+                transform: "translate(-50%, -55%)",
+                fontSize: "2rem",
               }}
             >
-              <Typography
-                onClick={handleClose}
-                sx={{
-                  position: "absolute",
-                  top: "0vw",
-                  right: "4vw",
-                  fontSize: "9vw",
-                  cursor: "pointer",
-                }}
-              >
-                ×
-              </Typography>
-              <Typography
-                variant="p"
-                sx={{
-                  fontSize: "5vw",
-                }}
-              >
-                名前と合言葉の両方を入力してね
-              </Typography>
-              <Typography
-                sx={{
-                  mt: "4vw",
-                  fontSize: "4vw",
-                }}
-              >
-                名前と合言葉を入力すると
-              </Typography>
-              <Typography
-                sx={{
-                  fontSize: "4vw",
-                }}
-              >
-                次のページへ進めるよ♪
-              </Typography>
-            </Box>
-          </Modal>
+              ウォッチをつけて
+              <br />
+              タップ
+            </Typography>
+          </Box>
         </Box>
+
+        <Button
+          component={motion.button}
+          whileHover={{ scale: 1.0 }}
+          whileTap={{ scale: 0.8 }}
+          onClick={handleSubmit}
+          sx={{
+            fontSize: "2rem",
+            fontWeight: "bold",
+            color: "white",
+            backgroundColor: "#ffdbdb",
+            marginTop: "5vh",
+            border: "10px solid white",
+            borderRadius: "15px",
+            padding: "2px 30px 2px 30px",
+          }}
+        >
+          タップ
+        </Button>
+        <Modal
+          component={motion.div}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ duration: 0.5 }}
+          open={open}
+          onClose={handleClose}
+          aria-labelledby="modal-modal-title"
+          aria-describedby="modal-modal-description"
+        >
+          <Box
+            sx={{
+              position: "absolute",
+              top: "50%",
+              left: "50%",
+              transform: "translate(-50%, -50%)",
+              height: "10vh",
+              width: "75vw",
+              maxWidth: "350px",
+              bgcolor: "background.paper",
+              border: "3px solid #FF4BB7",
+              borderRadius: "30px",
+              p: "8vw",
+            }}
+          >
+            <Typography
+              onClick={handleClose}
+              sx={{
+                position: "absolute",
+                top: "0vw",
+                right: "4vw",
+                fontSize: "2.5rem",
+                cursor: "pointer",
+              }}
+            >
+              ×
+            </Typography>
+            <Typography
+              variant="p"
+              sx={{
+                fontSize: "1.2rem",
+              }}
+            >
+              名前と合言葉の両方を入力してね
+            </Typography>
+            <Typography
+              sx={{
+                mt: "2vh",
+                fontSize: "1.1rem",
+              }}
+            >
+              名前と合言葉を入力すると
+            </Typography>
+            <Typography
+              sx={{
+                fontSize: "1.1rem",
+              }}
+            >
+              次のページへ進めるよ♪
+            </Typography>
+          </Box>
+        </Modal>
       </Box>
     </>
   );

--- a/src/pages/title/Titlepage.jsx
+++ b/src/pages/title/Titlepage.jsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import fukidashiBackImg from "../../assets/fukidashi.png";
 import { motion } from "framer-motion";
 import "./Titlepage.scss";
-import { Box, Typography } from "@mui/material";
+import { Box, Typography, Stack } from "@mui/material";
 
 export const Title = () => {
   const navigate = useNavigate();
@@ -14,57 +14,80 @@ export const Title = () => {
 
   return (
     <>
-      <Box>
+      <Stack
+        onClick={handleScreenChange}
+        direction="column"
+        sx={{
+          height: "90vh",
+          width: "90vw",
+          padding: "0 5vw",
+        }}
+      >
+        {/* 吹き出し */}
         <Box
           component={motion.div}
-          initial={{ opacity: 0, y: 400 }} //初期
-          animate={{ opacity: 1, y: 0 }} //表示される時
-          exit={{ opacity: 1, y: -400 }} //ページを離れる時の動き
+          initial={{ opacity: 0, y: 400 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 1, y: -400 }}
           transition={{ type: "spring" }}
         >
           <Box
             sx={{
-              mt: "50vw",
+              mt: "20vh",
               position: "relative",
             }}
           >
             <img
               src={fukidashiBackImg}
               style={{
-                width: "80%",
+                width: "80vw",
                 height: "auto",
+                maxWidth: "400px",
               }}
             />
             <Typography
               variant="body1"
               sx={{
                 margin: 0,
-                whiteSpace: "pre-line",
                 position: "absolute",
-                width: "70%",
+                width: "100%",
                 top: "50%",
                 left: "50%",
-                transform: "translate(-50%, -60%)",
-                fontSize: "10vw",
+                transform: "translate(-50%, -55%)",
+                fontSize: "2.5rem",
               }}
             >
-              あなたたちの相性診断
+              あなたたちの
+              <br />
+              相性診断
             </Typography>
           </Box>
         </Box>
+
+        {/* タイトル */}
         <Typography
           variant="body1"
+          component={motion.div}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{
+            duration: 1,
+            repeat: Infinity,
+            repeatType: "reverse",
+            ease: "easeInOut",
+          }}
           onClick={handleScreenChange}
           sx={{
-            mt: "15vw",
-            fontSize: "2.5em",
+            mt: "20vh",
+            fontSize: "2.5rem",
           }}
         >
           Heart
           <br />
           Link
         </Typography>
-      </Box>
+      </Stack>
     </>
   );
 };


### PR DESCRIPTION
# 変更
- PC画面だとうまく表示できていなかったのでCSSを変更してPCでもある程度使えるようにした

## CSS変更
手始めにtitle,formの２ページを変更した。
他のページも同じようにやっちゃっていいのか、それともPC画面用のレイアウトにするべきなのかは考えないといけない。
### 変更の画像
変更後
<img width="250" alt="スクリーンショット 2024-11-04 7 50 58" src="https://github.com/user-attachments/assets/74ee29ba-0e86-4e7f-beb0-890962d4fd7b">
<img width="250" alt="スクリーンショット 2024-11-04 7 51 48" src="https://github.com/user-attachments/assets/61bdd1a4-9fdc-46c8-af83-d2be9eadcd55">
変更前
<img width="250" alt="スクリーンショット 2024-11-04 7 52 53" src="https://github.com/user-attachments/assets/1607ba3c-3070-4a1a-8026-72e437ec777c">
<img width="250" alt="スクリーンショット 2024-11-04 7 52 35" src="https://github.com/user-attachments/assets/9378de89-fa6f-4de4-8a08-69f0d5dd55e0">
